### PR TITLE
Fix Temperature Quantities and Scales, fix om:hasScale

### DIFF
--- a/om-2.0.rdf
+++ b/om-2.0.rdf
@@ -19574,19 +19574,6 @@
     <om:hasDimension rdf:resource="&om;thermodynamicTemperature-Dimension"/>
   </om:RatioScale>
 
-  <owl:Class rdf:about="&om;KelvinTemperatureScale">
-    <rdfs:label xml:lang="en">Kelvin temperature scale</rdfs:label>
-    <rdfs:subClassOf rdf:resource="&om;RatioScale"/>
-    <rdfs:subClassOf rdf:resource="&om;ThermodynamicTemperatureScale"/>
-    <owl:equivalentClass>
-      <owl:Class>
-        <owl:oneOf rdf:parseType="Collection">
-          <om:RatioScale rdf:about="&om;KelvinScale"/>
-        </owl:oneOf>
-      </owl:Class>
-    </owl:equivalentClass>
-  </owl:Class>
-
   <owl:Class rdf:about="&om;KelvinTemperature">
     <rdfs:subClassOf>
       <owl:Restriction>
@@ -19596,15 +19583,11 @@
             <owl:unionOf rdf:parseType="Collection">
               <owl:Restriction>
                 <owl:onProperty rdf:resource="&om;hasUnit"/>
-                <owl:allValuesFrom>
-                  <owl:Class rdf:about="&om;KelvinTemperatureUnit"/>
-                </owl:allValuesFrom>
+                <owl:hasValue rdf:resource="&om;Kelvin"/>
               </owl:Restriction>
               <owl:Restriction>
                 <owl:onProperty rdf:resource="&om;hasScale"/>
-                <owl:allValuesFrom>
-                  <owl:Class rdf:about="&om;KelvinTemperatureScale"/>
-                </owl:allValuesFrom>
+                <owl:hasValue rdf:resource="&om;KelvinScale"/>
               </owl:Restriction>
             </owl:unionOf>
           </owl:Class>
@@ -19963,19 +19946,6 @@
     <om:hasUnit rdf:resource="&om;degreeCelsius"/>
   </om:IntervalScale>
 
-  <owl:Class rdf:about="&om;CelsiusTemperatureScale">
-    <rdfs:label xml:lang="en">Celsius temperature scale</rdfs:label>
-    <rdfs:subClassOf rdf:resource="&om;IntervalScale"/>
-    <rdfs:subClassOf rdf:resource="&om;ThermodynamicTemperatureScale"/>
-    <owl:equivalentClass>
-      <owl:Class>
-        <owl:oneOf rdf:parseType="Collection">
-          <om:IntervalScale rdf:about="&om;CelsiusScale"/>
-        </owl:oneOf>
-      </owl:Class>
-    </owl:equivalentClass>
-  </owl:Class>
-
   <owl:Class rdf:about="&om;CelsiusTemperature">
     <rdfs:subClassOf>
       <owl:Restriction>
@@ -19985,15 +19955,11 @@
             <owl:unionOf rdf:parseType="Collection">
               <owl:Restriction>
                 <owl:onProperty rdf:resource="&om;hasUnit"/>
-                <owl:allValuesFrom>
-                  <owl:Class rdf:about="&om;CelsiusTemperatureUnit"/>
-                </owl:allValuesFrom>
+                <owl:hasValue rdf:resource="&om;degreeCelsius"/>
               </owl:Restriction>
               <owl:Restriction>
                 <owl:onProperty rdf:resource="&om;hasScale"/>
-                <owl:allValuesFrom>
-                  <owl:Class rdf:about="&om;CelsiusTemperatureScale"/>
-                </owl:allValuesFrom>
+                <owl:hasValue rdf:resource="&om;CelsiusScale"/>
               </owl:Restriction>
             </owl:unionOf>
           </owl:Class>
@@ -20035,46 +20001,7 @@
     <om:hasScale rdf:resource="&om;KelvinScale"/>
     <om:hasUnit rdf:resource="&om;degreeReaumur"/>
     <om:hasDimension rdf:resource="&om;thermodynamicTemperature-Dimension"/>
-  </om:IntervalScale>	  
-
-  <owl:Class rdf:about="&om;FahrenheitTemperatureScale">
-    <rdfs:label xml:lang="en">Fahrenheit temperature scale</rdfs:label>
-    <rdfs:subClassOf rdf:resource="&om;IntervalScale"/>
-    <rdfs:subClassOf rdf:resource="&om;ThermodynamicTemperatureScale"/>
-    <owl:equivalentClass>
-      <owl:Class>
-        <owl:oneOf rdf:parseType="Collection">
-          <om:IntervalScale rdf:about="&om;FahrenheitScale"/>
-        </owl:oneOf>
-      </owl:Class>
-    </owl:equivalentClass>
-  </owl:Class>  	  
-
-  <owl:Class rdf:about="&om;RankineTemperatureScale">
-    <rdfs:label xml:lang="en">Rankine temperature scale</rdfs:label>
-    <rdfs:subClassOf rdf:resource="&om;RatioScale"/>
-    <rdfs:subClassOf rdf:resource="&om;ThermodynamicTemperatureScale"/>
-    <owl:equivalentClass>
-      <owl:Class>
-        <owl:oneOf rdf:parseType="Collection">
-          <om:RatioScale rdf:about="&om;RankineScale"/>
-        </owl:oneOf>
-      </owl:Class>
-    </owl:equivalentClass>
-  </owl:Class>  	  
-
-  <owl:Class rdf:about="&om;ReaumurTemperatureScale">
-    <rdfs:label xml:lang="en">Réaumur temperature scale</rdfs:label>
-    <rdfs:subClassOf rdf:resource="&om;IntervalScale"/>
-    <rdfs:subClassOf rdf:resource="&om;ThermodynamicTemperatureScale"/>
-    <owl:equivalentClass>
-      <owl:Class>
-        <owl:oneOf rdf:parseType="Collection">
-          <om:IntervalScale rdf:about="&om;ReaumurScale"/>
-        </owl:oneOf>
-      </owl:Class>
-    </owl:equivalentClass>
-  </owl:Class>  	  
+  </om:IntervalScale>
 
   <owl:Class rdf:about="&om;Temperature">
     <rdfs:subClassOf>
@@ -20111,15 +20038,11 @@
             <owl:unionOf rdf:parseType="Collection">
               <owl:Restriction>
                 <owl:onProperty rdf:resource="&om;hasUnit"/>
-                <owl:allValuesFrom>
-                  <owl:Class rdf:about="&om;FahrenheitTemperatureUnit"/>
-                </owl:allValuesFrom>
+                <owl:hasValue rdf:resource="&om;degreeFahrenheit"/>
               </owl:Restriction>
               <owl:Restriction>
                 <owl:onProperty rdf:resource="&om;hasScale"/>
-                <owl:allValuesFrom>
-                  <owl:Class rdf:about="&om;FahrenheitTemperatureScale"/>
-                </owl:allValuesFrom>
+                <owl:hasValue rdf:resource="&om;FahrenheitScale"/>
               </owl:Restriction>
             </owl:unionOf>
           </owl:Class>	
@@ -20137,15 +20060,11 @@
             <owl:unionOf rdf:parseType="Collection">
               <owl:Restriction>
                 <owl:onProperty rdf:resource="&om;hasUnit"/>
-                <owl:allValuesFrom>
-                  <owl:Class rdf:about="&om;RankineTemperatureUnit"/>
-                </owl:allValuesFrom>
+                <owl:hasValue rdf:resource="&om;degreeRankine"/>
               </owl:Restriction>
               <owl:Restriction>
                 <owl:onProperty rdf:resource="&om;hasScale"/>
-                <owl:allValuesFrom>
-                  <owl:Class rdf:about="&om;RankineTemperatureScale"/>
-                </owl:allValuesFrom>
+                <owl:hasValue rdf:resource="&om;RankineScale"/>
               </owl:Restriction>
             </owl:unionOf>
           </owl:Class>	
@@ -20163,15 +20082,11 @@
             <owl:unionOf rdf:parseType="Collection">
               <owl:Restriction>
                 <owl:onProperty rdf:resource="&om;hasUnit"/>
-                <owl:allValuesFrom>
-                  <owl:Class rdf:about="&om;ReaumurTemperatureUnit"/>
-                </owl:allValuesFrom>
+                <owl:hasValue rdf:resource="&om;degreeReaumur"/>
               </owl:Restriction>
               <owl:Restriction>
                 <owl:onProperty rdf:resource="&om;hasScale"/>
-                <owl:allValuesFrom>
-                  <owl:Class rdf:about="&om;ReaumurTemperatureScale"/>
-                </owl:allValuesFrom>
+                <owl:hasValue rdf:resource="&om;ReaumurScale"/>
               </owl:Restriction>
             </owl:unionOf>
           </owl:Class>	

--- a/om-2.0.rdf
+++ b/om-2.0.rdf
@@ -804,13 +804,7 @@
   <owl:ObjectProperty rdf:about="&om;hasScale">
     <rdfs:label xml:lang="en">has scale</rdfs:label>
     <rdfs:domain>
-      <owl:Class>
-        <owl:unionOf rdf:parseType="Collection">
-          <owl:Class rdf:about="&om;Scale"/>
-          <owl:Class rdf:about="&om;Quantity"/>
-          <owl:Class rdf:about="&om;ApplicationArea"/>
-        </owl:unionOf>
-      </owl:Class>
+      <owl:Class rdf:about="&om;Point"/>
     </rdfs:domain>
     <rdfs:range rdf:resource="&om;Scale"/>
   </owl:ObjectProperty>
@@ -17839,6 +17833,7 @@
     <om:usesQuantity rdf:resource="&om;Temperature"/>
     <om:usesQuantity rdf:resource="&om;ThermodynamicTemperature"/>
     <om:usesQuantity rdf:resource="&om;CelsiusTemperature"/>
+    <om:usesQuantity rdf:resource="&om;KelvinTemperature"/>
     <om:usesQuantity rdf:resource="&om;FahrenheitTemperature"/>
     <om:usesQuantity rdf:resource="&om;RankineTemperature"/>
     <om:usesQuantity rdf:resource="&om;ReaumurTemperature"/>
@@ -17933,6 +17928,7 @@
   <owl:Class rdf:about="&om;ThermodynamicTemperature">
     <rdfs:label xml:lang="en">thermodynamic temperature</rdfs:label>
     <rdfs:label xml:lang="nl">absolute temperatuur</rdfs:label>
+    <om:alternativeLabel xml:lang="en">absolute temperature</om:alternativeLabel>
     <om:alternativeLabel xml:lang="nl">thermodynamische temperatuur</om:alternativeLabel>
     <rdfs:comment xml:lang="en">Thermodynamic temperature is the absolute measure of temperature. Its zero point is the temperature at which the particle constituents of matter have minimal motion and can be no colder. Thermodynamic temperature is a base quantity in the International System of Units.</rdfs:comment>
     <rdfs:subClassOf rdf:resource="&om;Temperature"/>
@@ -17950,6 +17946,13 @@
   </owl:Class>
 
   <!-- Temperature Subclass Upper Ontology -->
+
+  <owl:Class rdf:about="&om;KelvinTemperature">
+    <rdfs:label xml:lang="en">Kelvin temperature</rdfs:label>
+    <rdfs:label xml:lang="nl">Kelvintemperatuur</rdfs:label>
+    <rdfs:subClassOf rdf:resource="&om;Temperature"/>
+    <om:symbol>T</om:symbol> 
+  </owl:Class>
 
   <owl:Class rdf:about="&om;FahrenheitTemperature">
     <rdfs:label xml:lang="en">Fahrenheit temperature</rdfs:label>
@@ -18944,6 +18947,10 @@
     <om:commonlyHasUnit rdf:resource="&om;degreeReaumur"/>
   </owl:Class>
 
+  <owl:Class rdf:about="&om;KelvinTemperature">
+    <om:commonlyHasUnit rdf:resource="&om;kelvin"/>
+  </owl:Class>
+
   <owl:Class rdf:about="&om;FahrenheitTemperature">
     <om:commonlyHasUnit rdf:resource="&om;degreeFahrenheit"/>
   </owl:Class>
@@ -19567,6 +19574,45 @@
     <om:hasDimension rdf:resource="&om;thermodynamicTemperature-Dimension"/>
   </om:RatioScale>
 
+  <owl:Class rdf:about="&om;KelvinTemperatureScale">
+    <rdfs:label xml:lang="en">Kelvin temperature scale</rdfs:label>
+    <rdfs:subClassOf rdf:resource="&om;RatioScale"/>
+    <rdfs:subClassOf rdf:resource="&om;ThermodynamicTemperatureScale"/>
+    <owl:equivalentClass>
+      <owl:Class>
+        <owl:oneOf rdf:parseType="Collection">
+          <om:RatioScale rdf:about="&om;KelvinScale"/>
+        </owl:oneOf>
+      </owl:Class>
+    </owl:equivalentClass>
+  </owl:Class>
+
+  <owl:Class rdf:about="&om;KelvinTemperature">
+    <rdfs:subClassOf>
+      <owl:Restriction>
+        <owl:onProperty rdf:resource="&om;hasValue"/>
+        <owl:allValuesFrom>
+          <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+              <owl:Restriction>
+                <owl:onProperty rdf:resource="&om;hasUnit"/>
+                <owl:allValuesFrom>
+                  <owl:Class rdf:about="&om;KelvinTemperatureUnit"/>
+                </owl:allValuesFrom>
+              </owl:Restriction>
+              <owl:Restriction>
+                <owl:onProperty rdf:resource="&om;hasScale"/>
+                <owl:allValuesFrom>
+                  <owl:Class rdf:about="&om;KelvinTemperatureScale"/>
+                </owl:allValuesFrom>
+              </owl:Restriction>
+            </owl:unionOf>
+          </owl:Class>
+        </owl:allValuesFrom>
+      </owl:Restriction>
+    </rdfs:subClassOf>
+  </owl:Class>
+
   <ThermodynamicTemperature rdf:about="&om;thermodynamicTemperatureOfTheTriplePointOfWater">
     <rdfs:label xml:lang="en">triple point of water thermodynamic temperature</rdfs:label>
     <om:hasPhenomenon rdf:resource="&om;triplePointOfWater"/>
@@ -19714,41 +19760,35 @@
 
   <owl:Class rdf:about="&om;ThermodynamicTemperatureScale">
     <rdfs:label xml:lang="en">thermodynamic temperature scale</rdfs:label>
-    <rdfs:subClassOf rdf:resource="&om;Scale"/> 
+    <om:alternativeLabel xml:lang="en">absolute temperature scale</om:alternativeLabel>
+    <rdfs:subClassOf rdf:resource="&om;Scale"/>
     <owl:equivalentClass>
       <owl:Class>
         <owl:oneOf rdf:parseType="Collection">
+          <om:IntervalScale rdf:about="&om;CelsiusScale"/>
+          <om:IntervalScale rdf:about="&om;FahrenheitScale"/>
+          <om:IntervalScale rdf:about="&om;ReaumurScale"/>
           <om:RatioScale rdf:about="&om;KelvinScale"/>
+          <om:RatioScale rdf:about="&om;RankineScale"/>
         </owl:oneOf>
       </owl:Class>
     </owl:equivalentClass>
-  </owl:Class>  	  
+  </owl:Class>
 
   <owl:Class rdf:about="&om;ThermodynamicTemperature">
-    <rdfs:subClassOf>
-      <owl:Restriction>
-        <owl:onProperty rdf:resource="&om;hasScale"/>
-        <owl:hasValue rdf:resource="&om;KelvinScale"/>
-      </owl:Restriction>
-    </rdfs:subClassOf>
     <rdfs:subClassOf>
       <owl:Restriction>
         <owl:onProperty rdf:resource="&om;hasValue"/>
         <owl:allValuesFrom>
           <owl:Restriction>
-            <owl:onProperty rdf:resource="&om;hasUnit"/>
+            <owl:onProperty rdf:resource="&om;hasScale"/>
             <owl:allValuesFrom>
-              <owl:Class>
-                <owl:unionOf rdf:parseType="Collection">
-                  <owl:Class rdf:about="&om;ThermodynamicTemperatureUnit"/>
-                  <owl:Class rdf:about="&om;ThermodynamicTemperatureScale"/>
-                </owl:unionOf>
-              </owl:Class>
+              <owl:Class rdf:about="&om;ThermodynamicTemperatureScale"/>
             </owl:allValuesFrom>
-          </owl:Restriction>	
+          </owl:Restriction>
         </owl:allValuesFrom>
-      </owl:Restriction>     
-    </rdfs:subClassOf>     
+      </owl:Restriction>
+    </rdfs:subClassOf>
   </owl:Class>
 
   <!-- Celsius Scale Ontology -->
@@ -19925,7 +19965,8 @@
 
   <owl:Class rdf:about="&om;CelsiusTemperatureScale">
     <rdfs:label xml:lang="en">Celsius temperature scale</rdfs:label>
-    <rdfs:subClassOf rdf:resource="&om;Scale"/> 
+    <rdfs:subClassOf rdf:resource="&om;IntervalScale"/>
+    <rdfs:subClassOf rdf:resource="&om;ThermodynamicTemperatureScale"/>
     <owl:equivalentClass>
       <owl:Class>
         <owl:oneOf rdf:parseType="Collection">
@@ -19933,33 +19974,32 @@
         </owl:oneOf>
       </owl:Class>
     </owl:equivalentClass>
-  </owl:Class>  	  
+  </owl:Class>
 
   <owl:Class rdf:about="&om;CelsiusTemperature">
     <rdfs:subClassOf>
       <owl:Restriction>
-        <owl:onProperty rdf:resource="&om;hasScale"/>
-        <owl:hasValue rdf:resource="&om;CelsiusScale"/>
-      </owl:Restriction>
-    </rdfs:subClassOf>
-    <rdfs:subClassOf>
-      <owl:Restriction>
         <owl:onProperty rdf:resource="&om;hasValue"/>
         <owl:allValuesFrom>
-          <owl:Restriction>
-            <owl:onProperty rdf:resource="&om;hasUnit"/>
-            <owl:allValuesFrom>
-              <owl:Class>
-                <owl:unionOf rdf:parseType="Collection">
+          <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+              <owl:Restriction>
+                <owl:onProperty rdf:resource="&om;hasUnit"/>
+                <owl:allValuesFrom>
                   <owl:Class rdf:about="&om;CelsiusTemperatureUnit"/>
+                </owl:allValuesFrom>
+              </owl:Restriction>
+              <owl:Restriction>
+                <owl:onProperty rdf:resource="&om;hasScale"/>
+                <owl:allValuesFrom>
                   <owl:Class rdf:about="&om;CelsiusTemperatureScale"/>
-                </owl:unionOf>
-              </owl:Class>
-            </owl:allValuesFrom>
-          </owl:Restriction>	
+                </owl:allValuesFrom>
+              </owl:Restriction>
+            </owl:unionOf>
+          </owl:Class>
         </owl:allValuesFrom>
-      </owl:Restriction>     
-    </rdfs:subClassOf>     
+      </owl:Restriction>
+    </rdfs:subClassOf>
   </owl:Class>
 
   <!-- Temperature Scale Ontology -->
@@ -19995,26 +20035,12 @@
     <om:hasScale rdf:resource="&om;KelvinScale"/>
     <om:hasUnit rdf:resource="&om;degreeReaumur"/>
     <om:hasDimension rdf:resource="&om;thermodynamicTemperature-Dimension"/>
-  </om:IntervalScale>
-
-  <owl:Class rdf:about="&om;Temperature_scale">
-    <rdfs:subClassOf rdf:resource="&om;Scale"/> 
-    <owl:equivalentClass>
-      <owl:Class>
-        <owl:oneOf rdf:parseType="Collection">
-          <om:IntervalScale rdf:about="&om;CelsiusScale"/>
-          <om:IntervalScale rdf:about="&om;FahrenheitScale"/>
-          <om:IntervalScale rdf:about="&om;ReaumurScale"/>
-          <om:RatioScale rdf:about="&om;KelvinScale"/>
-          <om:RatioScale rdf:about="&om;RankineScale"/>
-        </owl:oneOf>
-      </owl:Class>
-    </owl:equivalentClass>
-  </owl:Class>  	  
+  </om:IntervalScale>	  
 
   <owl:Class rdf:about="&om;FahrenheitTemperatureScale">
     <rdfs:label xml:lang="en">Fahrenheit temperature scale</rdfs:label>
-    <rdfs:subClassOf rdf:resource="&om;Scale"/> 
+    <rdfs:subClassOf rdf:resource="&om;IntervalScale"/>
+    <rdfs:subClassOf rdf:resource="&om;ThermodynamicTemperatureScale"/>
     <owl:equivalentClass>
       <owl:Class>
         <owl:oneOf rdf:parseType="Collection">
@@ -20026,7 +20052,8 @@
 
   <owl:Class rdf:about="&om;RankineTemperatureScale">
     <rdfs:label xml:lang="en">Rankine temperature scale</rdfs:label>
-    <rdfs:subClassOf rdf:resource="&om;Scale"/> 
+    <rdfs:subClassOf rdf:resource="&om;RatioScale"/>
+    <rdfs:subClassOf rdf:resource="&om;ThermodynamicTemperatureScale"/>
     <owl:equivalentClass>
       <owl:Class>
         <owl:oneOf rdf:parseType="Collection">
@@ -20038,7 +20065,8 @@
 
   <owl:Class rdf:about="&om;ReaumurTemperatureScale">
     <rdfs:label xml:lang="en">Réaumur temperature scale</rdfs:label>
-    <rdfs:subClassOf rdf:resource="&om;Scale"/> 
+    <rdfs:subClassOf rdf:resource="&om;IntervalScale"/>
+    <rdfs:subClassOf rdf:resource="&om;ThermodynamicTemperatureScale"/>
     <owl:equivalentClass>
       <owl:Class>
         <owl:oneOf rdf:parseType="Collection">
@@ -20051,119 +20079,105 @@
   <owl:Class rdf:about="&om;Temperature">
     <rdfs:subClassOf>
       <owl:Restriction>
-        <owl:onProperty rdf:resource="&om;hasScale"/>
+        <owl:onProperty rdf:resource="&om;hasValue"/>
         <owl:allValuesFrom>
           <owl:Class>
-            <owl:oneOf rdf:parseType="Collection">
-              <om:IntervalScale rdf:about="&om;CelsiusScale"/>
-              <om:IntervalScale rdf:about="&om;FahrenheitScale"/>
-              <om:IntervalScale rdf:about="&om;ReaumurScale"/>
-              <om:RatioScale rdf:about="&om;KelvinScale"/>
-              <om:RatioScale rdf:about="&om;RankineScale"/>
-            </owl:oneOf>
+            <owl:unionOf rdf:parseType="Collection">
+              <owl:Restriction>
+                <owl:onProperty rdf:resource="&om;hasUnit"/>
+                <owl:allValuesFrom>
+                  <owl:Class rdf:about="&om;TemperatureUnit"/>
+                </owl:allValuesFrom>
+              </owl:Restriction>
+              <owl:Restriction>
+                <owl:onProperty rdf:resource="&om;hasScale"/>
+                <owl:allValuesFrom>
+                  <owl:Class rdf:about="&om;ThermodynamicTemperatureScale"/>
+                </owl:allValuesFrom>
+              </owl:Restriction>
+            </owl:unionOf>
           </owl:Class>
         </owl:allValuesFrom>
       </owl:Restriction>
     </rdfs:subClassOf>
-    <rdfs:subClassOf>
-      <owl:Restriction>
-        <owl:onProperty rdf:resource="&om;hasValue"/>
-        <owl:allValuesFrom>
-          <owl:Restriction>
-            <owl:onProperty rdf:resource="&om;hasUnit"/>
-            <owl:allValuesFrom>
-              <owl:Class>
-                <owl:unionOf rdf:parseType="Collection">
-                  <owl:Class rdf:about="&om;TemperatureUnit"/>
-                  <owl:Class rdf:about="&om;Temperature_scale"/>
-                </owl:unionOf>
-              </owl:Class>
-            </owl:allValuesFrom>
-          </owl:Restriction>	
-        </owl:allValuesFrom>
-      </owl:Restriction>     
-    </rdfs:subClassOf>     
   </owl:Class>
 
   <owl:Class rdf:about="&om;FahrenheitTemperature">
     <rdfs:subClassOf>
       <owl:Restriction>
-        <owl:onProperty rdf:resource="&om;hasScale"/>
-        <owl:hasValue rdf:resource="&om;FahrenheitScale"/>
-      </owl:Restriction>
-    </rdfs:subClassOf>
-    <rdfs:subClassOf>
-      <owl:Restriction>
         <owl:onProperty rdf:resource="&om;hasValue"/>
         <owl:allValuesFrom>
-          <owl:Restriction>
-            <owl:onProperty rdf:resource="&om;hasUnit"/>
-            <owl:allValuesFrom>
-              <owl:Class>
-                <owl:unionOf rdf:parseType="Collection">
+          <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+              <owl:Restriction>
+                <owl:onProperty rdf:resource="&om;hasUnit"/>
+                <owl:allValuesFrom>
                   <owl:Class rdf:about="&om;FahrenheitTemperatureUnit"/>
+                </owl:allValuesFrom>
+              </owl:Restriction>
+              <owl:Restriction>
+                <owl:onProperty rdf:resource="&om;hasScale"/>
+                <owl:allValuesFrom>
                   <owl:Class rdf:about="&om;FahrenheitTemperatureScale"/>
-                </owl:unionOf>
-              </owl:Class>
-            </owl:allValuesFrom>
-          </owl:Restriction>	
+                </owl:allValuesFrom>
+              </owl:Restriction>
+            </owl:unionOf>
+          </owl:Class>	
         </owl:allValuesFrom>
       </owl:Restriction>     
-    </rdfs:subClassOf>     
+    </rdfs:subClassOf> 
   </owl:Class>
 
   <owl:Class rdf:about="&om;RankineTemperature">
     <rdfs:subClassOf>
       <owl:Restriction>
-        <owl:onProperty rdf:resource="&om;hasScale"/>
-        <owl:hasValue rdf:resource="&om;RankineScale"/>
-      </owl:Restriction>
-    </rdfs:subClassOf>
-    <rdfs:subClassOf>
-      <owl:Restriction>
         <owl:onProperty rdf:resource="&om;hasValue"/>
         <owl:allValuesFrom>
-          <owl:Restriction>
-            <owl:onProperty rdf:resource="&om;hasUnit"/>
-            <owl:allValuesFrom>
-              <owl:Class>
-                <owl:unionOf rdf:parseType="Collection">
+          <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+              <owl:Restriction>
+                <owl:onProperty rdf:resource="&om;hasUnit"/>
+                <owl:allValuesFrom>
                   <owl:Class rdf:about="&om;RankineTemperatureUnit"/>
+                </owl:allValuesFrom>
+              </owl:Restriction>
+              <owl:Restriction>
+                <owl:onProperty rdf:resource="&om;hasScale"/>
+                <owl:allValuesFrom>
                   <owl:Class rdf:about="&om;RankineTemperatureScale"/>
-                </owl:unionOf>
-              </owl:Class>
-            </owl:allValuesFrom>
-          </owl:Restriction>	
+                </owl:allValuesFrom>
+              </owl:Restriction>
+            </owl:unionOf>
+          </owl:Class>	
         </owl:allValuesFrom>
       </owl:Restriction>     
-    </rdfs:subClassOf>     
+    </rdfs:subClassOf>   
   </owl:Class>
 
   <owl:Class rdf:about="&om;ReaumurTemperature">
     <rdfs:subClassOf>
       <owl:Restriction>
-        <owl:onProperty rdf:resource="&om;hasScale"/>
-        <owl:hasValue rdf:resource="&om;ReaumurScale"/>
-      </owl:Restriction>
-    </rdfs:subClassOf>
-    <rdfs:subClassOf>
-      <owl:Restriction>
         <owl:onProperty rdf:resource="&om;hasValue"/>
         <owl:allValuesFrom>
-          <owl:Restriction>
-            <owl:onProperty rdf:resource="&om;hasUnit"/>
-            <owl:allValuesFrom>
-              <owl:Class>
-                <owl:unionOf rdf:parseType="Collection">
+          <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+              <owl:Restriction>
+                <owl:onProperty rdf:resource="&om;hasUnit"/>
+                <owl:allValuesFrom>
                   <owl:Class rdf:about="&om;ReaumurTemperatureUnit"/>
+                </owl:allValuesFrom>
+              </owl:Restriction>
+              <owl:Restriction>
+                <owl:onProperty rdf:resource="&om;hasScale"/>
+                <owl:allValuesFrom>
                   <owl:Class rdf:about="&om;ReaumurTemperatureScale"/>
-                </owl:unionOf>
-              </owl:Class>
-            </owl:allValuesFrom>
-          </owl:Restriction>	
+                </owl:allValuesFrom>
+              </owl:Restriction>
+            </owl:unionOf>
+          </owl:Class>	
         </owl:allValuesFrom>
       </owl:Restriction>     
-    </rdfs:subClassOf>     
+    </rdfs:subClassOf>    
   </owl:Class>
 
   <!-- Dimension Ontologies -->

--- a/om-2.0.rdf
+++ b/om-2.0.rdf
@@ -19572,6 +19572,7 @@
     <rdfs:label xml:lang="zh">开氏温标</rdfs:label>
     <om:alternativeLabel xml:lang="en">International Kelvin Temperature scale of 1990</om:alternativeLabel>
     <om:hasDimension rdf:resource="&om;thermodynamicTemperature-Dimension"/>
+    <rdf:type rdf:resource="&om;ThermodynamicTemperatureScale"/>
   </om:RatioScale>
 
   <owl:Class rdf:about="&om;KelvinTemperature">
@@ -19745,17 +19746,6 @@
     <rdfs:label xml:lang="en">thermodynamic temperature scale</rdfs:label>
     <om:alternativeLabel xml:lang="en">absolute temperature scale</om:alternativeLabel>
     <rdfs:subClassOf rdf:resource="&om;Scale"/>
-    <owl:equivalentClass>
-      <owl:Class>
-        <owl:oneOf rdf:parseType="Collection">
-          <om:IntervalScale rdf:about="&om;CelsiusScale"/>
-          <om:IntervalScale rdf:about="&om;FahrenheitScale"/>
-          <om:IntervalScale rdf:about="&om;ReaumurScale"/>
-          <om:RatioScale rdf:about="&om;KelvinScale"/>
-          <om:RatioScale rdf:about="&om;RankineScale"/>
-        </owl:oneOf>
-      </owl:Class>
-    </owl:equivalentClass>
   </owl:Class>
 
   <owl:Class rdf:about="&om;ThermodynamicTemperature">
@@ -19782,6 +19772,7 @@
     <rdfs:label xml:lang="zh">摄氏温标</rdfs:label>
     <om:alternativeLabel xml:lang="en">International Celsius Temperature scale of 1990</om:alternativeLabel>
     <om:hasDimension rdf:resource="&om;thermodynamicTemperature-Dimension"/>
+    <rdf:type rdf:resource="&om;ThermodynamicTemperatureScale"/>
   </om:IntervalScale>
 
   <om:FixedPoint rdf:about="&om;_-270.15To-268.15OnTheCelsiusScale">
@@ -19979,6 +19970,7 @@
     <om:hasScale rdf:resource="&om;KelvinScale"/>
     <om:hasUnit rdf:resource="&om;degreeFahrenheit"/>
     <om:hasDimension rdf:resource="&om;thermodynamicTemperature-Dimension"/>
+    <rdf:type rdf:resource="&om;ThermodynamicTemperatureScale"/>
   </om:IntervalScale>
 
   <om:RatioScale rdf:about="&om;RankineScale">
@@ -19990,6 +19982,7 @@
     <om:hasScale rdf:resource="&om;KelvinScale"/>
     <om:hasUnit rdf:resource="&om;degreeRankine"/>
     <om:hasDimension rdf:resource="&om;thermodynamicTemperature-Dimension"/>
+    <rdf:type rdf:resource="&om;ThermodynamicTemperatureScale"/>
   </om:RatioScale>
 
   <om:IntervalScale rdf:about="&om;ReaumurScale">
@@ -20001,6 +19994,7 @@
     <om:hasScale rdf:resource="&om;KelvinScale"/>
     <om:hasUnit rdf:resource="&om;degreeReaumur"/>
     <om:hasDimension rdf:resource="&om;thermodynamicTemperature-Dimension"/>
+    <rdf:type rdf:resource="&om;ThermodynamicTemperatureScale"/>
   </om:IntervalScale>
 
   <owl:Class rdf:about="&om;Temperature">


### PR DESCRIPTION
This PR solves issue #85 and #13.

Changes:
* fix domain of om:hasScale
* fix restrictions of the om:Temperature and its subclasses regarding the use of om:hasUnit and om:hasScale
* add missing quantity om:KelvinTemperature
* add alternative label for [thermodynamic temperature](http://www.ontology-of-units-of-measure.org/resource/om-2/ThermodynamicTemperature): `absolute temperature`
* add alternative label for [thermodynamic temperature scale](http://www.ontology-of-units-of-measure.org/resource/om-2/ThermodynamicTemperatureScale): `absolute temperature scale`
* use om:oneOf in temperature quantities to make the singleton temperature scale helper classes unnecessary
* remove the singleton temperature scale helper classes
* associate instances of om:ThermodynamicTemperatureScale using rdf:type instead of owl:oneOf