### PR TITLE
Add / Update Sustainability Quantities and Units

### DIFF
--- a/om-2.0.rdf
+++ b/om-2.0.rdf
@@ -38718,11 +38718,11 @@
     <rdfs:label xml:lang="nl">duurzaamheid</rdfs:label>
     <om:usesQuantity rdf:resource="&om;CarbonDioxideEquivalentMass"/>
     <om:usesQuantity rdf:resource="&om;CarbonDioxideEquivalentMassPerEnergy"/>
-    <om:usesUnit rdf:resource="&om;gramOfCarbonDioxideEquivalent"/>
-    <om:usesUnit rdf:resource="&om;kilogramOfCarbonDioxideEquivalent"/>
-    <om:usesUnit rdf:resource="&om;petagramOfCarbonDioxideEquivalent"/>
-    <om:usesUnit rdf:resource="&om;tonneOfCarbonDioxideEquivalent"/>
-    <om:usesUnit rdf:resource="&om;gigatonneOfCarbonDioxideEquivalent"/>
+    <om:usesUnit rdf:resource="&om;gramCarbonDioxideEquivalent"/>
+    <om:usesUnit rdf:resource="&om;kilogramCarbonDioxideEquivalent"/>
+    <om:usesUnit rdf:resource="&om;petagramCarbonDioxideEquivalent"/>
+    <om:usesUnit rdf:resource="&om;tonneCarbonDioxideEquivalent"/>
+    <om:usesUnit rdf:resource="&om;gigatonneCarbonDioxideEquivalent"/>
     <om:usesUnit rdf:resource="&om;gramOfCarbonDioxideEquivalentPerKilowattHour"/>
     <om:usesUnit rdf:resource="&om;kilogramOfCarbonDioxideEquivalentPerMegaWattHour"/>
     <om:usesUnit rdf:resource="&om;tonneOfCarbonDioxideEquivalentPerGigaWattHour"/>
@@ -38792,8 +38792,8 @@
   <!-- Contents -->
 
   <!-- Carbon Dioxide Equivalent Ontology -->
-  <!-- Gram of Carbon Dioxide Equivalent Multiples and Submultiples Ontology -->
-  <!-- Gram of Carbon Dioxide Equivalent Per Watt Hour Multiples and Submultiples Ontology -->
+  <!-- Gram Carbon Dioxide Equivalent Multiples and Submultiples Ontology -->
+  <!-- Gram Carbon Dioxide Equivalent Per Watt Hour Multiples and Submultiples Ontology -->
 
   <!-- Carbon Dioxide Equivalent Ontology -->
 
@@ -38804,42 +38804,42 @@
     <om:hasDimension rdf:resource="&om;dimensionOne"/>
   </om:Unit>
 
-  <!-- Gram of Carbon Dioxide Equivalent Multiples and Submultiples Ontology -->
+  <!-- Gram Carbon Dioxide Equivalent Multiples and Submultiples Ontology -->
 
-  <om:UnitMultiplication rdf:about="&om;gramOfCarbonDioxideEquivalent">
-    <rdfs:label xml:lang="en">gram of carbon dioxide equivalent</rdfs:label>
+  <om:UnitMultiplication rdf:about="&om;gramCarbonDioxideEquivalent">
+    <rdfs:label xml:lang="en">gram carbon dioxide equivalent</rdfs:label>
     <om:symbol>g CO2eq</om:symbol>
 	<om:alternativeSymbol>g·CO2eq</om:alternativeSymbol>
     <hasTerm1 rdf:resource="&om;gram"/>
     <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
   </om:UnitMultiplication>
 
-  <om:UnitMultiplication rdf:about="&om;kilogramOfCarbonDioxideEquivalent">
-    <rdfs:label xml:lang="en">kilogram of carbon dioxide equivalent</rdfs:label>
+  <om:UnitMultiplication rdf:about="&om;kilogramCarbonDioxideEquivalent">
+    <rdfs:label xml:lang="en">kilogram carbon dioxide equivalent</rdfs:label>
     <om:symbol>kg CO2eq</om:symbol>
 	<om:alternativeSymbol>kg·CO2eq</om:alternativeSymbol>
     <hasTerm1 rdf:resource="&om;kilogram"/>
     <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
   </om:UnitMultiplication>
 
-  <om:UnitMultiplication rdf:about="&om;petagramOfCarbonDioxideEquivalent">
-    <rdfs:label xml:lang="en">petagram of carbon dioxide equivalent</rdfs:label>
+  <om:UnitMultiplication rdf:about="&om;petagramCarbonDioxideEquivalent">
+    <rdfs:label xml:lang="en">petagram carbon dioxide equivalent</rdfs:label>
     <om:symbol>Pg CO2eq</om:symbol>
 	<om:alternativeSymbol>Pg·CO2eq</om:alternativeSymbol>
     <hasTerm1 rdf:resource="&om;petagram"/>
     <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
   </om:UnitMultiplication>
 
-  <om:UnitMultiplication rdf:about="&om;tonneOfCarbonDioxideEquivalent">
-    <rdfs:label xml:lang="en">tonne of carbon dioxide equivalent</rdfs:label>
+  <om:UnitMultiplication rdf:about="&om;tonneCarbonDioxideEquivalent">
+    <rdfs:label xml:lang="en">tonne carbon dioxide equivalent</rdfs:label>
     <om:symbol>t CO2eq</om:symbol>
 	<om:alternativeSymbol>t·CO2eq</om:alternativeSymbol>
     <hasTerm1 rdf:resource="&om;tonne"/>
     <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
   </om:UnitMultiplication>
 
-  <om:UnitMultiplication rdf:about="&om;gigatonneOfCarbonDioxideEquivalent">
-    <rdfs:label xml:lang="en">gigatonne of carbon dioxide equivalent</rdfs:label>
+  <om:UnitMultiplication rdf:about="&om;gigatonneCarbonDioxideEquivalent">
+    <rdfs:label xml:lang="en">gigatonne carbon dioxide equivalent</rdfs:label>
     <om:symbol>Gt CO2eq</om:symbol>
 	<om:alternativeSymbol>Gt·CO2eq</om:alternativeSymbol>
     <hasTerm1 rdf:resource="&om;gigatonne"/>
@@ -38847,11 +38847,11 @@
   </om:UnitMultiplication>
 
   <owl:Class rdf:about="&om;CarbonDioxideEquivalentMass">
-    <om:commonlyHasUnit rdf:resource="&om;gramOfCarbonDioxideEquivalent"/>
-    <om:commonlyHasUnit rdf:resource="&om;kilogramOfCarbonDioxideEquivalent"/>
-    <om:commonlyHasUnit rdf:resource="&om;petagramOfCarbonDioxideEquivalent"/>
-    <om:commonlyHasUnit rdf:resource="&om;tonneOfCarbonDioxideEquivalent"/>
-    <om:commonlyHasUnit rdf:resource="&om;gigatonneOfCarbonDioxideEquivalent"/>
+    <om:commonlyHasUnit rdf:resource="&om;gramCarbonDioxideEquivalent"/>
+    <om:commonlyHasUnit rdf:resource="&om;kilogramCarbonDioxideEquivalent"/>
+    <om:commonlyHasUnit rdf:resource="&om;petagramCarbonDioxideEquivalent"/>
+    <om:commonlyHasUnit rdf:resource="&om;tonneCarbonDioxideEquivalent"/>
+    <om:commonlyHasUnit rdf:resource="&om;gigatonneCarbonDioxideEquivalent"/>
   </owl:Class>
 
   <owl:Class rdf:about="&om;CarbonDioxideEquivalentMassUnit">
@@ -38860,9 +38860,9 @@
     <owl:equivalentClass>
       <owl:Class>
         <owl:oneOf rdf:parseType="Collection">
-          <om:Unit rdf:about="&om;gramOfCarbonDioxideEquivalent"/>
-          <om:PrefixedUnit rdf:about="&om;kilogramOfCarbonDioxideEquivalent"/>
-          <om:Unit rdf:about="&om;tonneOfCarbonDioxideEquivalent"/>
+          <om:Unit rdf:about="&om;gramCarbonDioxideEquivalent"/>
+          <om:PrefixedUnit rdf:about="&om;kilogramCarbonDioxideEquivalent"/>
+          <om:Unit rdf:about="&om;tonneCarbonDioxideEquivalent"/>
         </owl:oneOf>
       </owl:Class>
     </owl:equivalentClass>
@@ -38884,26 +38884,26 @@
     </rdfs:subClassOf>     
   </owl:Class>
 
-  <!-- Gram of Carbon Dioxide Equivalent Per Watt Hour Multiples and Submultiples Ontology -->
+  <!-- Gram Carbon Dioxide Equivalent Per Watt Hour Multiples and Submultiples Ontology -->
 
   <om:UnitDivision rdf:about="&om;gramOfCarbonDioxideEquivalentPerKilowattHour">
-    <rdfs:label xml:lang="en">gram of carbon dioxide equivalent per kilowatt hour</rdfs:label>
+    <rdfs:label xml:lang="en">gram carbon dioxide equivalent per kilowatt hour</rdfs:label>
     <om:symbol>gCO2eq/kWh</om:symbol>
-    <om:hasNumerator rdf:resource="&om;gramOfCarbonDioxideEquivalent"/>
+    <om:hasNumerator rdf:resource="&om;gramCarbonDioxideEquivalent"/>
     <om:hasDenominator rdf:resource="&om;kilowattHour"/>
   </om:UnitDivision>
 
   <om:UnitDivision rdf:about="&om;kilogramOfCarbonDioxideEquivalentPerMegawattHour">
-    <rdfs:label xml:lang="en">kilogram of carbon dioxide equivalent per megawatt hour</rdfs:label>
+    <rdfs:label xml:lang="en">kilogram carbon dioxide equivalent per megawatt hour</rdfs:label>
     <om:symbol>kgCO2eq/MWh</om:symbol>
-    <om:hasNumerator rdf:resource="&om;kilogramOfCarbonDioxideEquivalent"/>
+    <om:hasNumerator rdf:resource="&om;kilogramCarbonDioxideEquivalent"/>
     <om:hasDenominator rdf:resource="&om;megawattHour"/>
   </om:UnitDivision>
 
   <om:UnitDivision rdf:about="&om;tonneOfCarbonDioxideEquivalentPerGigawattHour">
-    <rdfs:label xml:lang="en">tonne of carbon dioxide equivalent per gigawatt hour</rdfs:label>
+    <rdfs:label xml:lang="en">tonne carbon dioxide equivalent per gigawatt hour</rdfs:label>
     <om:symbol>tCO2eq/GWh</om:symbol>
-    <om:hasNumerator rdf:resource="&om;tonneOfCarbonDioxideEquivalent"/>
+    <om:hasNumerator rdf:resource="&om;tonneCarbonDioxideEquivalent"/>
     <om:hasDenominator rdf:resource="&om;gigawattHour"/>
   </om:UnitDivision>
 

--- a/om-2.0.rdf
+++ b/om-2.0.rdf
@@ -38806,42 +38806,40 @@
 
   <!-- Gram of Carbon Dioxide Equivalent Multiples and Submultiples Ontology -->
 
-  <om:Unit rdf:about="&om;gramOfCarbonDioxideEquivalent">
+  <om:UnitMultiplication rdf:about="&om;gramOfCarbonDioxideEquivalent">
     <rdfs:label xml:lang="en">gram of carbon dioxide equivalent</rdfs:label>
     <om:symbol>gCO2eq</om:symbol>
-    <rdf:type rdf:resource="&om;SingularUnit"/>
-    <!-- hasDefinition --> <om:hasFactor rdf:datatype="&xsd;decimal">0.001</om:hasFactor>
-    <!-- hasDefinition --> <om:hasUnit rdf:resource="&om;kilogramOfCarbonDioxideEquivalent"/>
-  </om:Unit>
+    <hasTerm1 rdf:resource="&om;gram"/>
+    <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
+  </om:UnitMultiplication>
 
-  <om:PrefixedUnit rdf:about="&om;kilogramOfCarbonDioxideEquivalent">
+  <om:UnitMultiplication rdf:about="&om;kilogramOfCarbonDioxideEquivalent">
     <rdfs:label xml:lang="en">kilogram of carbon dioxide equivalent</rdfs:label>
     <om:symbol>kgCO2eq</om:symbol>
-    <om:hasPrefix rdf:resource="&om;kilo"/>
-    <!-- hasSingularUnit --> <om:hasUnit rdf:resource="&om;gramOfCarbonDioxideEquivalent"/>
-  </om:PrefixedUnit>
+    <hasTerm1 rdf:resource="&om;kilogram"/>
+    <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
+  </om:UnitMultiplication>
 
-  <om:PrefixedUnit rdf:about="&om;petagramOfCarbonDioxideEquivalent">
+  <om:UnitMultiplication rdf:about="&om;petagramOfCarbonDioxideEquivalent">
     <rdfs:label xml:lang="en">petagram of carbon dioxide equivalent</rdfs:label>
     <om:symbol>PgCO2eq</om:symbol>
-    <om:hasPrefix rdf:resource="&om;peta"/>
-    <!-- hasSingularUnit --> <om:hasUnit rdf:resource="&om;gramOfCarbonDioxideEquivalent"/>
-  </om:PrefixedUnit>
+    <hasTerm1 rdf:resource="&om;petagram"/>
+    <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
+  </om:UnitMultiplication>
 
-  <om:Unit rdf:about="&om;tonneOfCarbonDioxideEquivalent">
+  <om:UnitMultiplication rdf:about="&om;tonneOfCarbonDioxideEquivalent">
     <rdfs:label xml:lang="en">tonne of carbon dioxide equivalent</rdfs:label>
     <om:symbol>tCO2eq</om:symbol>
-    <rdf:type rdf:resource="&om;SingularUnit"/>
-    <!-- hasDefinition --> <om:hasFactor rdf:datatype="&xsd;decimal">1000</om:hasFactor>
-    <!-- hasDefinition --> <om:hasUnit rdf:resource="&om;kilogramOfCarbonDioxideEquivalent"/>
-  </om:Unit>
+    <hasTerm1 rdf:resource="&om;tonne"/>
+    <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
+  </om:UnitMultiplication>
 
-  <om:PrefixedUnit rdf:about="&om;gigatonneOfCarbonDioxideEquivalent">
+  <om:UnitMultiplication rdf:about="&om;gigatonneOfCarbonDioxideEquivalent">
     <rdfs:label xml:lang="en">gigatonne of carbon dioxide equivalent</rdfs:label>
     <om:symbol>GtCO2eq</om:symbol>
-    <om:hasPrefix rdf:resource="&om;giga"/>
-    <!-- hasSingularUnit --> <om:hasUnit rdf:resource="&om;tonneOfCarbonDioxideEquivalent"/>
-  </om:PrefixedUnit>
+    <hasTerm1 rdf:resource="&om;gigatonne"/>
+    <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
+  </om:UnitMultiplication>
 
   <owl:Class rdf:about="&om;CarbonDioxideEquivalentMass">
     <om:commonlyHasUnit rdf:resource="&om;gramOfCarbonDioxideEquivalent"/>

--- a/om-2.0.rdf
+++ b/om-2.0.rdf
@@ -38808,35 +38808,40 @@
 
   <om:UnitMultiplication rdf:about="&om;gramOfCarbonDioxideEquivalent">
     <rdfs:label xml:lang="en">gram of carbon dioxide equivalent</rdfs:label>
-    <om:symbol>gCO2eq</om:symbol>
+    <om:symbol>g CO2eq</om:symbol>
+	<om:alternativeSymbol>g·CO2eq</om:alternativeSymbol>
     <hasTerm1 rdf:resource="&om;gram"/>
     <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
   </om:UnitMultiplication>
 
   <om:UnitMultiplication rdf:about="&om;kilogramOfCarbonDioxideEquivalent">
     <rdfs:label xml:lang="en">kilogram of carbon dioxide equivalent</rdfs:label>
-    <om:symbol>kgCO2eq</om:symbol>
+    <om:symbol>kg CO2eq</om:symbol>
+	<om:alternativeSymbol>kg·CO2eq</om:alternativeSymbol>
     <hasTerm1 rdf:resource="&om;kilogram"/>
     <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
   </om:UnitMultiplication>
 
   <om:UnitMultiplication rdf:about="&om;petagramOfCarbonDioxideEquivalent">
     <rdfs:label xml:lang="en">petagram of carbon dioxide equivalent</rdfs:label>
-    <om:symbol>PgCO2eq</om:symbol>
+    <om:symbol>Pg CO2eq</om:symbol>
+	<om:alternativeSymbol>Pg·CO2eq</om:alternativeSymbol>
     <hasTerm1 rdf:resource="&om;petagram"/>
     <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
   </om:UnitMultiplication>
 
   <om:UnitMultiplication rdf:about="&om;tonneOfCarbonDioxideEquivalent">
     <rdfs:label xml:lang="en">tonne of carbon dioxide equivalent</rdfs:label>
-    <om:symbol>tCO2eq</om:symbol>
+    <om:symbol>t CO2eq</om:symbol>
+	<om:alternativeSymbol>t·CO2eq</om:alternativeSymbol>
     <hasTerm1 rdf:resource="&om;tonne"/>
     <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
   </om:UnitMultiplication>
 
   <om:UnitMultiplication rdf:about="&om;gigatonneOfCarbonDioxideEquivalent">
     <rdfs:label xml:lang="en">gigatonne of carbon dioxide equivalent</rdfs:label>
-    <om:symbol>GtCO2eq</om:symbol>
+    <om:symbol>Gt CO2eq</om:symbol>
+	<om:alternativeSymbol>Gt·CO2eq</om:alternativeSymbol>
     <hasTerm1 rdf:resource="&om;gigatonne"/>
     <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
   </om:UnitMultiplication>

--- a/om-2.0.rdf
+++ b/om-2.0.rdf
@@ -38760,7 +38760,7 @@
     <rdfs:label xml:lang="en">gram of carbon dioxide equivalent</rdfs:label>
     <om:symbol>gCO2eq</om:symbol>
     <rdf:type rdf:resource="&om;SingularUnit"/>
-    <!-- hasDefinition --> <om:hasFactor rdf:datatype="&xsd;decimal">0.0010</om:hasFactor>
+    <!-- hasDefinition --> <om:hasFactor rdf:datatype="&xsd;decimal">0.001</om:hasFactor>
     <!-- hasDefinition --> <om:hasUnit rdf:resource="&om;kilogramOfCarbonDioxideEquivalent"/>
   </om:Unit>
 

--- a/om-2.0.rdf
+++ b/om-2.0.rdf
@@ -38809,7 +38809,7 @@
   <om:UnitMultiplication rdf:about="&om;gramCarbonDioxideEquivalent">
     <rdfs:label xml:lang="en">gram carbon dioxide equivalent</rdfs:label>
     <om:symbol>g CO2eq</om:symbol>
-	<om:alternativeSymbol>g·CO2eq</om:alternativeSymbol>
+    <om:alternativeSymbol>g·CO2eq</om:alternativeSymbol>
     <hasTerm1 rdf:resource="&om;gram"/>
     <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
   </om:UnitMultiplication>
@@ -38817,7 +38817,7 @@
   <om:UnitMultiplication rdf:about="&om;kilogramCarbonDioxideEquivalent">
     <rdfs:label xml:lang="en">kilogram carbon dioxide equivalent</rdfs:label>
     <om:symbol>kg CO2eq</om:symbol>
-	<om:alternativeSymbol>kg·CO2eq</om:alternativeSymbol>
+    <om:alternativeSymbol>kg·CO2eq</om:alternativeSymbol>
     <hasTerm1 rdf:resource="&om;kilogram"/>
     <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
   </om:UnitMultiplication>
@@ -38825,7 +38825,7 @@
   <om:UnitMultiplication rdf:about="&om;petagramCarbonDioxideEquivalent">
     <rdfs:label xml:lang="en">petagram carbon dioxide equivalent</rdfs:label>
     <om:symbol>Pg CO2eq</om:symbol>
-	<om:alternativeSymbol>Pg·CO2eq</om:alternativeSymbol>
+    <om:alternativeSymbol>Pg·CO2eq</om:alternativeSymbol>
     <hasTerm1 rdf:resource="&om;petagram"/>
     <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
   </om:UnitMultiplication>
@@ -38833,7 +38833,7 @@
   <om:UnitMultiplication rdf:about="&om;tonneCarbonDioxideEquivalent">
     <rdfs:label xml:lang="en">tonne carbon dioxide equivalent</rdfs:label>
     <om:symbol>t CO2eq</om:symbol>
-	<om:alternativeSymbol>t·CO2eq</om:alternativeSymbol>
+    <om:alternativeSymbol>t·CO2eq</om:alternativeSymbol>
     <hasTerm1 rdf:resource="&om;tonne"/>
     <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
   </om:UnitMultiplication>
@@ -38841,7 +38841,7 @@
   <om:UnitMultiplication rdf:about="&om;gigatonneCarbonDioxideEquivalent">
     <rdfs:label xml:lang="en">gigatonne carbon dioxide equivalent</rdfs:label>
     <om:symbol>Gt CO2eq</om:symbol>
-	<om:alternativeSymbol>Gt·CO2eq</om:alternativeSymbol>
+    <om:alternativeSymbol>Gt·CO2eq</om:alternativeSymbol>
     <hasTerm1 rdf:resource="&om;gigatonne"/>
     <hasTerm2 rdf:resource="&om;carbonDioxideEquivalent"/>
   </om:UnitMultiplication>
@@ -38866,7 +38866,7 @@
         </owl:oneOf>
       </owl:Class>
     </owl:equivalentClass>
-  </owl:Class>  	  
+  </owl:Class>
 
   <owl:Class rdf:about="&om;CarbonDioxideEquivalentMass">
     <rdfs:subClassOf>
@@ -38878,10 +38878,10 @@
             <owl:allValuesFrom>
               <owl:Class rdf:about="&om;CarbonDioxideEquivalentMassUnit"/>
             </owl:allValuesFrom>
-          </owl:Restriction>	
+          </owl:Restriction>
         </owl:allValuesFrom>
-      </owl:Restriction>     
-    </rdfs:subClassOf>     
+      </owl:Restriction>
+    </rdfs:subClassOf>
   </owl:Class>
 
   <!-- Gram Carbon Dioxide Equivalent Per Watt Hour Multiples and Submultiples Ontology -->
@@ -38925,7 +38925,7 @@
         </owl:oneOf>
       </owl:Class>
     </owl:equivalentClass>
-  </owl:Class>  	  
+  </owl:Class>
 
   <owl:Class rdf:about="&om;CarbonDioxideEquivalentMassPerEnergy">
     <rdfs:subClassOf>
@@ -38937,10 +38937,10 @@
             <owl:allValuesFrom>
               <owl:Class rdf:about="&om;CarbonDioxideEquivalentMassPerEnergyUnit"/>
             </owl:allValuesFrom>
-          </owl:Restriction>	
+          </owl:Restriction>
         </owl:allValuesFrom>
-      </owl:Restriction>     
-    </rdfs:subClassOf>     
+      </owl:Restriction>
+    </rdfs:subClassOf>
   </owl:Class>
 
   <!-- Economics Ontology -->

--- a/om-2.0.rdf
+++ b/om-2.0.rdf
@@ -38749,12 +38749,60 @@
     <rdfs:subClassOf rdf:resource="&om;Quantity"/>
   </owl:Class>
 
+  <!-- Global Warming Potential Upper Ontology -->
+
+  <owl:Class rdf:about="&om;GlobalWarmingPotential">
+    <rdfs:label xml:lang="en">global warming potential</rdfs:label>
+    <om:alternativeLabel xml:lang="en">relative cumulative forcing index</om:alternativeLabel>
+    <rdfs:comment xml:lang="en">Global warming potential is an index of the total energy added to the climate system by the phenomenon relative to the total energy added by CO2 for some time horizon. The global warming potential for a time horizon of 100 has been determined as the standard metric for reporting emissions of various greenhouse gases relative to CO2 emissions by a decision in the Kyoto Protocol.</rdfs:comment>
+    <rdfs:subClassOf rdf:resource="&om;Quantity"/>
+    <om:symbol>GWP</om:symbol>
+    <ombibo:reference rdf:resource="http://www.wikidata.org/entity/Q28324305"/>
+  </owl:Class>
+
+  <owl:Class rdf:about="&om;GlobalWarmingPotential20YearHorizon">
+    <rdfs:label xml:lang="en">global warming potential for a time horizon of 20</rdfs:label>
+    <om:alternativeLabel xml:lang="en">CO2 equivalent emissions</om:alternativeLabel>
+    <rdfs:comment xml:lang="en">Global warming potential is an index of the total energy added to the climate system by the phenomenon relative to the total energy added by CO2 for a time horizon of 20 years.</rdfs:comment>
+    <rdfs:subClassOf rdf:resource="&om;GlobalWarmingPotential"/>
+    <om:symbol>GWP20</om:symbol>
+    <ombibo:reference rdf:resource="http://www.wikidata.org/entity/Q28324305"/>
+  </owl:Class>
+
+  <owl:Class rdf:about="&om;GlobalWarmingPotential100YearHorizon">
+    <rdfs:label xml:lang="en">global warming potential for a time horizon of 100</rdfs:label>
+    <om:alternativeLabel xml:lang="en">CO2 equivalent emissions</om:alternativeLabel>
+    <rdfs:comment xml:lang="en">Global warming potential is an index of the total energy added to the climate system by the phenomenon relative to the total energy added by CO2 for a time horizon of 100 years. It has been determined as the standard metric for reporting emissions of various greenhouse gases relative to CO2 emissions by a decision in the Kyoto Protocol.</rdfs:comment>
+    <rdfs:subClassOf rdf:resource="&om;GlobalWarmingPotential"/>
+    <om:symbol>GWP100</om:symbol>
+    <ombibo:reference rdf:resource="http://www.wikidata.org/entity/Q28324305"/>
+  </owl:Class>
+
+  <owl:Class rdf:about="&om;GlobalWarmingPotential500YearHorizon">
+    <rdfs:label xml:lang="en">global warming potential for a time horizon of 500</rdfs:label>
+    <om:alternativeLabel xml:lang="en">CO2 equivalent emissions</om:alternativeLabel>
+    <rdfs:comment xml:lang="en">Global warming potential is an index of the total energy added to the climate system by the phenomenon relative to the total energy added by CO2 for a time horizon of 500 years.</rdfs:comment>
+    <rdfs:subClassOf rdf:resource="&om;GlobalWarmingPotential"/>
+    <om:symbol>GWP500</om:symbol>
+    <ombibo:reference rdf:resource="http://www.wikidata.org/entity/Q28324305"/>
+  </owl:Class>
+
   <!-- Unit of Measure Ontologies -->
 
   <!-- Contents -->
 
+  <!-- Carbon Dioxide Equivalent Ontology -->
   <!-- Gram of Carbon Dioxide Equivalent Multiples and Submultiples Ontology -->
   <!-- Gram of Carbon Dioxide Equivalent Per Watt Hour Multiples and Submultiples Ontology -->
+
+  <!-- Carbon Dioxide Equivalent Ontology -->
+
+  <om:Unit rdf:about="&om;carbonDioxideEquivalent">
+    <rdfs:label xml:lang="en">carbon dioxide equivalent</rdfs:label>
+    <om:symbol>CO2eq</om:symbol>
+    <rdf:type rdf:resource="&om;SingularUnit"/>
+    <om:hasDimension rdf:resource="&om;dimensionOne"/>
+  </om:Unit>
 
   <!-- Gram of Carbon Dioxide Equivalent Multiples and Submultiples Ontology -->
 

--- a/om-2.0.rdf
+++ b/om-2.0.rdf
@@ -38720,7 +38720,9 @@
     <om:usesQuantity rdf:resource="&om;CarbonDioxideEquivalentMassPerEnergy"/>
     <om:usesUnit rdf:resource="&om;gramOfCarbonDioxideEquivalent"/>
     <om:usesUnit rdf:resource="&om;kilogramOfCarbonDioxideEquivalent"/>
+    <om:usesUnit rdf:resource="&om;petagramOfCarbonDioxideEquivalent"/>
     <om:usesUnit rdf:resource="&om;tonneOfCarbonDioxideEquivalent"/>
+    <om:usesUnit rdf:resource="&om;gigatonneOfCarbonDioxideEquivalent"/>
     <om:usesUnit rdf:resource="&om;gramOfCarbonDioxideEquivalentPerKilowattHour"/>
     <om:usesUnit rdf:resource="&om;kilogramOfCarbonDioxideEquivalentPerMegaWattHour"/>
     <om:usesUnit rdf:resource="&om;tonneOfCarbonDioxideEquivalentPerGigaWattHour"/>
@@ -38771,6 +38773,13 @@
     <!-- hasSingularUnit --> <om:hasUnit rdf:resource="&om;gramOfCarbonDioxideEquivalent"/>
   </om:PrefixedUnit>
 
+  <om:PrefixedUnit rdf:about="&om;petagramOfCarbonDioxideEquivalent">
+    <rdfs:label xml:lang="en">petagram of carbon dioxide equivalent</rdfs:label>
+    <om:symbol>PgCO2eq</om:symbol>
+    <om:hasPrefix rdf:resource="&om;peta"/>
+    <!-- hasSingularUnit --> <om:hasUnit rdf:resource="&om;gramOfCarbonDioxideEquivalent"/>
+  </om:PrefixedUnit>
+
   <om:Unit rdf:about="&om;tonneOfCarbonDioxideEquivalent">
     <rdfs:label xml:lang="en">tonne of carbon dioxide equivalent</rdfs:label>
     <om:symbol>tCO2eq</om:symbol>
@@ -38779,10 +38788,19 @@
     <!-- hasDefinition --> <om:hasUnit rdf:resource="&om;kilogramOfCarbonDioxideEquivalent"/>
   </om:Unit>
 
+  <om:PrefixedUnit rdf:about="&om;gigatonneOfCarbonDioxideEquivalent">
+    <rdfs:label xml:lang="en">gigatonne of carbon dioxide equivalent</rdfs:label>
+    <om:symbol>GtCO2eq</om:symbol>
+    <om:hasPrefix rdf:resource="&om;giga"/>
+    <!-- hasSingularUnit --> <om:hasUnit rdf:resource="&om;tonneOfCarbonDioxideEquivalent"/>
+  </om:PrefixedUnit>
+
   <owl:Class rdf:about="&om;CarbonDioxideEquivalentMass">
     <om:commonlyHasUnit rdf:resource="&om;gramOfCarbonDioxideEquivalent"/>
     <om:commonlyHasUnit rdf:resource="&om;kilogramOfCarbonDioxideEquivalent"/>
+    <om:commonlyHasUnit rdf:resource="&om;petagramOfCarbonDioxideEquivalent"/>
     <om:commonlyHasUnit rdf:resource="&om;tonneOfCarbonDioxideEquivalent"/>
+    <om:commonlyHasUnit rdf:resource="&om;gigatonneOfCarbonDioxideEquivalent"/>
   </owl:Class>
 
   <owl:Class rdf:about="&om;CarbonDioxideEquivalentMassUnit">


### PR DESCRIPTION
This PR addresses #87.
The initial PR is thought as a baseline for discussion and further collaborative changes.

By now, the unit `carbon dioxide equivalent` is defined as singular unit. That (and many other things, see #87) need to get improved or added.